### PR TITLE
Point to right tree for ingress tls

### DIFF
--- a/templates/celery-flower/ingress.yaml
+++ b/templates/celery-flower/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
 {{- if .Values.celerFlower.ingress.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.celerFlower.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}

--- a/templates/django-server/ingress.yaml
+++ b/templates/django-server/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
 {{- if .Values.djangoServer.ingress.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.djangoServer.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}

--- a/templates/django-server/ingress.yaml
+++ b/templates/django-server/ingress.yaml
@@ -34,7 +34,7 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-server
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}


### PR DESCRIPTION
Without, enabling tls in `values.yml` fails with:

```
Error: template: django/templates/django-server/ingress.yaml:21:19: executing "django/templates/django-server/ingress.yaml" at <.Values.ingress.tls>: nil pointer evaluating interface {}.tls
```