### PR TITLE
Django Server Readiness / Liveness Probe Path Values

### DIFF
--- a/templates/django-server/deployment.yaml
+++ b/templates/django-server/deployment.yaml
@@ -38,13 +38,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.djangoServer.probe.readiness.path }}
               port: django
             initialDelaySeconds: 15
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.djangoServer.probe.liveness.path }}
               port: django
             failureThreshold: 1
             periodSeconds: 10

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,12 @@ djangoServer:
     #    hosts:
     #      - chart-example.local
 
+  probe:
+    readiness:
+      path: /
+    liveness:
+      path: /
+
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Since we do not always use the default root path, it would be awesome to customize the path which is used for readiness and liveness checks.